### PR TITLE
Unknown dates

### DIFF
--- a/Encoded Letters/Edgeworth_Beinecke_330_unknown01.xml
+++ b/Encoded Letters/Edgeworth_Beinecke_330_unknown01.xml
@@ -79,8 +79,7 @@
                      <idno type="VIAF">71477273</idno>
                      <idno type="SNAC">62567029</idno>
                   </persName>
-                   to <persName ref="./Personography.xml#DarnE1">Lady Elizabeth Darnley</persName>, <placeName><!--Location where letter was sent--></placeName>, 
-                  <date when="1111-01-01"><!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date>
+                   to <persName ref="./Personography.xml#DarnE1">Lady Elizabeth Darnley</persName> 
                </head>
                <physDesc>
                   <!-- optional physical description of the letter goes here: paper size and condition, seal, postmarks, etc.-->

--- a/Encoded Letters/Edgeworth_Beinecke_330_unknown_03.xml
+++ b/Encoded Letters/Edgeworth_Beinecke_330_unknown_03.xml
@@ -80,8 +80,7 @@
                      <idno type="VIAF">71477273</idno>
                      <idno type="SNAC">62567029</idno>
                   </persName>
-                        to <persName ref="./Personography.xml#MileX1">Mrs. Miles<!--Recipient Name--></persName>, <placeName><!--Location where letter was sent--></placeName>, 
-                        <date when="1111-01-01">Unknown<!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date>
+                        to <persName ref="./Personography.xml#MileX1">Mrs. Miles</persName>
                </head>
                <physDesc>
                         <!-- optional physical description of the letter goes here: paper size and condition, seal, postmarks, etc.-->
@@ -200,16 +199,6 @@
                <persName ref="./Personography.xml#MileX1">Mrs. Miles<!--RECIPIENT NAME--></persName>
             </correspAction>
          </correspDesc>
-         <textClass>
-            <keywords scheme="">
-               <list type="simple">
-                  <item>English literature</item>
-                  <item>History</item>
-               </list>
-            </keywords>
-            <catRef target="#f7" scheme="#f"/>
-            <catRef target="#hist #el" scheme="locSUB"/>
-         </textClass>
       </profileDesc>
       <revisionDesc>
          <change when="2021-01-01" who="Id_who">
@@ -223,10 +212,6 @@
             <pb n="2" facs="Edgeworth_Beinecke_330_unknown_03_page02.jpg"/>
             <!--filenames for photos associated with this letter. Example: <pb n="1" facs="image1.jpg image2.jpg image3.jpg"/> -->
             <opener>
-               <dateline><!--If there's no date line, omit this element. Record in the order in which it is written on the letter.-->
-                  <name type="place" ref="Id_where"/>
-                  <date when="1816-08-04"/>
-               </dateline>
                <salute>
                   <persName>
                             My <persName ref="./Personography.xml#MileX1">dear Madam</persName>

--- a/Encoded Letters/Edgeworth_Beinecke_330_unknown_04.xml
+++ b/Encoded Letters/Edgeworth_Beinecke_330_unknown_04.xml
@@ -80,8 +80,7 @@
                      <idno type="VIAF">71477273</idno>
                      <idno type="SNAC">62567029</idno>
                   </persName>
-                   to <persName ref="./Personography.xml#MileX1">Mrs. Miles</persName>, <placeName><!--Location where letter was sent--></placeName>, 
-                  <date when="1111-01-01"><!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date>
+                   to <persName ref="./Personography.xml#MileX1">Mrs. Miles</persName>
                </head>
                <physDesc>
                   <!-- optional physical description of the letter goes here: paper size and condition, seal, postmarks, etc.-->

--- a/Encoded Letters/Edgeworth_Geneve_33_2_unknown_04.xml
+++ b/Encoded Letters/Edgeworth_Geneve_33_2_unknown_04.xml
@@ -79,8 +79,7 @@
                             <idno type="VIAF">71477273</idno>
                             <idno type="SNAC">62567029</idno>
                         </persName>
-                        to <persName>Unknown</persName>, <placeName><!--Location where letter was sent--></placeName>, 
-                        <date when="1111-01-01"><!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date>
+                        to <persName>Unknown</persName>
                     </head>
                     <physDesc>
                         <!-- optional physical description of the letter goes here: paper size and condition, seal, postmarks, etc.-->
@@ -128,8 +127,6 @@
                 <pb n="1" facs="Edgeworth_Geneve_33_2_unknown_04_page02.jpg"/>
                 <!--filenames for photos associated with this letter. Example: <pb n="1" facs="image1.jpg image2.jpg image3.jpg"/> -->
                 <opener>
-                    <dateline>
-                        <date when="1816-08-04"/></dateline>
                     <salute>
                         <persName>
                             <!-- Use if letter has a saluation ("Dear Sir," for example). If not, delete this line.-->

--- a/Encoded Letters/Edgeworth_Harvard_604762_1848_12_28.xml
+++ b/Encoded Letters/Edgeworth_Harvard_604762_1848_12_28.xml
@@ -6,7 +6,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Letter from Maria Edgeworth to Dr. Ashburner, December 28, 1848<!--Recipient Name, Month Day, YYYY--></title>
+            <title>Letter from Maria Edgeworth to Dr. Ashburner, December 28, 1848</title>
             <author>Maria Edgeworth</author>
             <editor ref="Id_who">
                     Eliza Wilcox<!--Editor on the Maria Edgeworth Letters Project overseeing the coding of this particular letter: FirstName LastName -->
@@ -198,16 +198,6 @@
                <persName>unknown</persName>
             </correspAction>
          </correspDesc>
-         <textClass>
-            <keywords scheme="">
-               <list type="simple">
-                  <item>English literature</item>
-                  <item>History</item>
-               </list>
-            </keywords>
-            <catRef target="#f7" scheme="#f"/>
-            <catRef target="#hist #el" scheme="locSUB"/>
-         </textClass>
       </profileDesc>
       <revisionDesc>
          <change when="2021-01-01" who="Id_who">

--- a/Encoded Letters/Edgeworth_Huntington_XXXX_unknown_02.xml
+++ b/Encoded Letters/Edgeworth_Huntington_XXXX_unknown_02.xml
@@ -231,16 +231,6 @@
                <persName ref="./Personography.xml#BeauA1">Alicia Beaufort (Wilson)</persName>
             </correspAction>
          </correspDesc>
-         <textClass>
-            <keywords scheme="">
-               <list type="simple">
-                  <item>English literature</item>
-                  <item>History</item>
-               </list>
-            </keywords>
-            <catRef target="#f7" scheme="#f"/>
-            <catRef target="#hist #el" scheme="locSUB"/>
-         </textClass>
       </profileDesc>
       <revisionDesc>
          <change when="2021-01-01" who="Id_who">

--- a/Encoded Letters/Edgeworth_Iowa_0001_1844-12.xml
+++ b/Encoded Letters/Edgeworth_Iowa_0001_1844-12.xml
@@ -199,7 +199,7 @@
                <dateline>
                   <placeName ref="./Placeography.xml#Edgeworthstown_IE">Edgeworths Town</placeName>
                   <lb/>
-                  <date when="1844-12-18"/>Dec<hi rend="superscript">r</hi>. 18<hi rend="superscript">th</hi>. 1844<lb/>
+                  <date when="1844-12-18">Dec<hi rend="superscript">r</hi>. 18<hi rend="superscript">th</hi>. 1844<lb/></date>
                </dateline>
                <salute>
                   Dear Sir<lb/>

--- a/Encoded Letters/Edgeworth_Princeton_C0962_undated-01.xml
+++ b/Encoded Letters/Edgeworth_Princeton_C0962_undated-01.xml
@@ -59,8 +59,7 @@
                      <forename>Maria</forename>
                      <surname>Edgeworth</surname>
                   </persName>
-                   to <persName>Madam Miles</persName>, <placeName><!--Location where letter was sent--></placeName>, 
-                  <date when="1111-01-01"><!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date><!--What do we do if there is no date?-->
+                   to <persName>Madam Miles</persName>
                </head>
                <physDesc>
                   <!-- optional physical description of the letter goes here: paper size and condition, seal, postmarks, etc.-->

--- a/Encoded Letters/Edgeworth_Princeton_C0962_undated-02.xml
+++ b/Encoded Letters/Edgeworth_Princeton_C0962_undated-02.xml
@@ -58,9 +58,7 @@
                      <forename>Maria</forename>
                      <surname>Edgeworth</surname>
                   </persName>
-                   to <persName ref="./Personography.xml#BowrJ1">John Bowring</persName>, <placeName><!--Location where letter was sent--></placeName>, 
-                  <date when="1111-01-01"><!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date>
-                  <!--What do we do if we have an unknown date?-->
+                   to <persName ref="./Personography.xml#BowrJ1">John Bowring</persName>
                </head>
                <physDesc>
                   <p>Page features watermarks that read "CWH 13"</p>

--- a/Encoded Letters/Edgeworth_Princeton_C0962_undated-03.xml
+++ b/Encoded Letters/Edgeworth_Princeton_C0962_undated-03.xml
@@ -58,8 +58,7 @@
                      <forename>Maria</forename>
                      <surname>Edgeworth</surname>
                   </persName>
-                  to <persName ref="./Personography.xml#HallX2">Madam Hall</persName>, <placeName ref="./Placeography.xml#59-Sloane-Street_FR">59 Sloane Street</placeName>, 
-                  <date when="1111-01-01"><!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date> <!--What do we do if the letter is undated?-->
+                  to <persName ref="./Personography.xml#HallX2">Madam Hall</persName>, <placeName ref="./Placeography.xml#59-Sloane-Street_FR">59 Sloane Street</placeName>
                </head>
                <physDesc>
                   <!-- optional physical description of the letter goes here: paper size and condition, seal, postmarks, etc.-->

--- a/Encoded Letters/Edgeworth_Princeton_C0962_undated-04.xml
+++ b/Encoded Letters/Edgeworth_Princeton_C0962_undated-04.xml
@@ -58,8 +58,7 @@
                      <forename>Lucy Jane</forename>
                      <surname>Edgeworth</surname>
                   </persName>
-                  to <persName ref="./Personography.xml#EdgeM1">Maria Edgeworth</persName>, <placeName><!--Location where letter was sent--></placeName>, 
-                  <date when="1111-01-01"><!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date> <!--What do we do when there is no date on the letter?-->
+                  to <persName ref="./Personography.xml#EdgeM1">Maria Edgeworth</persName>
                </head>
                <physDesc><p>Black seal present on address leaf</p></physDesc>
             </msDesc>

--- a/Encoded Letters/Edgeworth_Princeton_C1644_unknown_02.xml
+++ b/Encoded Letters/Edgeworth_Princeton_C1644_unknown_02.xml
@@ -6,7 +6,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Letter from Maria Edgeworth to Mr. Rogers, Date Unknown</title>
+            <title>Letter from Maria Edgeworth to Mr. Rogers, date unknown</title>
             <author>Maria Edgeworth</author>
             <editor ref="Id_who">
                Jamie Kramer
@@ -66,8 +66,7 @@
                      <surname>Edgeworth</surname>
                   </persName>
                   to <persName ref="./Personography.xml#RogeX1">
-                     <abbr type="title">Mr.</abbr> Rogers</persName>, <placeName><!--Location where letter was sent--></placeName>, 
-                  <date>unknown</date>
+                     <abbr type="title">Mr.</abbr> Rogers</persName>
                </head>
                <physDesc>
                   <!-- optional physical description of the letter goes here: paper size and condition, seal, postmarks, etc.-->

--- a/Encoded Letters/Edgeworth_Princeton_C1664_undated-01.xml
+++ b/Encoded Letters/Edgeworth_Princeton_C1664_undated-01.xml
@@ -59,8 +59,7 @@
                      <forename>John</forename>
                      <surname>Murray</surname>
                   </persName>
-                  to <persName ref="./Personography.xml#RomiA1">Anne Garbett Romilly</persName>, <placeName ref="./Placeography.xml#Albemarle-Street_ENK">Albemarle Street</placeName>, 
-                  <date when="1111-01-01"><!-- Transcribe the date as it appears on the letter itself. Enter a numeric standardized date value in @when. --></date><!--What do we do when there is no date?-->
+                  to <persName ref="./Personography.xml#RomiA1">Anne Garbett Romilly</persName>, <placeName ref="./Placeography.xml#Albemarle-Street_ENK">Albemarle Street</placeName>
                </head>
                <physDesc>
                   <!-- optional physical description of the letter goes here: paper size and condition, seal, postmarks, etc.-->


### PR DESCRIPTION
Related Issue - [23](https://github.com/Maria-Edgeworth-Letters-Project/me-tei/issues/23) 

## What does this Pull Request do?

In our weekly RA meeting, the question came up of what to do with @when within the date element when the date is unknown. In the template the @when value had been put in as 1111-01-01 for validation purposes. In our existing XML for letters within unknown dates, this placeholder value had been left without editing. This PR removes the entire date element (including @when) if the date is unknown.

## How should this be tested?

Check to see if:
- All instances of unknown dates have been addressed (e.g., no letters with 1111-01-01 within @when still exist). If not, please comment with the filename of any outstanding letter(s).
- All XML is valid
- You agree with the way this was addressed (complete removal rather than `<date>Unknown</date>` etc.)

## Additional Notes

A few changes were made that did not involve removing the date element. In particular, `Edgeworth_Harvard_604762_unknown.xml` was renamed to `Edgeworth_Harvard_604762_1848_12_28.xml` as it had a date to include. Within GitHub this change appears as deleting the original file and adding a completely new one.

I also changed the wrapping for date for `Edgeworth_Iowa_0001_1844-12.xml` as it didn't include the text values within it.

If you have questions or concerns about any changes present in the commit, please comment. I'm including everyone for informational purposes (but only one approval is needed).
